### PR TITLE
Experiment: per-variation Google Shopping feed

### DIFF
--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -693,10 +693,12 @@ describe("normalizeColor", () => {
     expect(normalizeColor("Blue")).toBe("Blue");
   });
 
-  it("returns undefined for non-color values", () => {
+  it("returns undefined for values with digits", () => {
     expect(normalizeColor("Idye3")).toBeUndefined();
-    expect(normalizeColor("Kotuku")).toBeUndefined();
-    expect(normalizeColor("Glow-white rim")).toBeUndefined();
+  });
+
+  it("strips 'rim' suffix and normalizes", () => {
+    expect(normalizeColor("Glow-white rim")).toBe("Glow/White");
   });
 });
 

--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -674,7 +674,14 @@ describe("normalizeColor", () => {
   it("strips 'swirl' suffix", () => {
     expect(normalizeColor("Pink swirl")).toBe("Pink");
     expect(normalizeColor("Orange swirl")).toBe("Orange");
-    expect(normalizeColor("Blue-pink swirl")).toBe("Blue-pink");
+    expect(normalizeColor("Blue-pink swirl")).toBe("Blue/Pink");
+  });
+
+  it("converts hyphenated color pairs to slash-separated", () => {
+    expect(normalizeColor("Lime-purple")).toBe("Lime/Purple");
+    expect(normalizeColor("Pink-blue")).toBe("Pink/Blue");
+    expect(normalizeColor("White-orange")).toBe("White/Orange");
+    expect(normalizeColor("Charcoal-red")).toBe("Charcoal/Red");
   });
 
   it("passes through standard colors unchanged", () => {

--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -6,12 +6,9 @@ import {
   parseVariationColor,
   normalizeColor,
   slugify,
-  aggregateItems,
   expandVariations,
-  toGoogleProduct,
   variationToGoogleProduct,
   generateTsvFeed,
-  type AggregatedItem,
   type VariationItem,
   type SquareInventoryData,
 } from "./google-feed.js";
@@ -189,308 +186,6 @@ describe("slugify", () => {
   });
 });
 
-describe("aggregateItems", () => {
-  it("combines variants into single item", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/ruru.jpg"),
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          description: "A putter",
-          imageIds: ["img-1"],
-          ecomUri: "https://mdgcshop.square.site/product/ruru/25",
-          variations: [
-            { id: "var-1", name: "Atomic/Pink/171", priceAmount: 2200n },
-            { id: "var-2", name: "Cosmic/Blue/170", priceAmount: 2500n },
-          ],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 2),
-        makeInventoryCount("var-2", 3),
-      ],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items).toHaveLength(1);
-    expect(items[0]).toMatchObject({
-      itemId: "item-1",
-      name: "Ruru",
-      totalQuantity: 5,
-      minPrice: 2200,
-    });
-  });
-
-  it("uses minimum price from in-stock variants only", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeItem({
-          id: "item-1",
-          name: "Disc",
-          ecomUri: "https://example.com/disc",
-          variations: [
-            { id: "var-1", name: "Cheap but out of stock", priceAmount: 1500n },
-            { id: "var-2", name: "In stock", priceAmount: 2500n },
-          ],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 0), // out of stock
-        makeInventoryCount("var-2", 3), // in stock
-      ],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items[0].minPrice).toBe(2500); // not 1500
-    expect(items[0].totalQuantity).toBe(3);
-  });
-
-  it("uses minimum price across variants", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeItem({
-          id: "item-1",
-          name: "Disc",
-          ecomUri: "https://example.com/disc",
-          variations: [
-            { id: "var-1", name: "Cheap", priceAmount: 1500n },
-            { id: "var-2", name: "Expensive", priceAmount: 3000n },
-          ],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 1),
-        makeInventoryCount("var-2", 1),
-      ],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items[0].minPrice).toBe(1500);
-  });
-
-  it("keeps separate items separate", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          ecomUri: "https://example.com/ruru",
-          variations: [{ id: "var-1", priceAmount: 2200n }],
-        }),
-        makeItem({
-          id: "item-2",
-          name: "Tui",
-          ecomUri: "https://example.com/tui",
-          variations: [{ id: "var-2", priceAmount: 2200n }],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 2),
-        makeInventoryCount("var-2", 3),
-      ],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items).toHaveLength(2);
-  });
-
-  it("extracts brand from category hierarchy", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/ruru.jpg"),
-        // Parent category for brands
-        makeCategory("brands-cat", "BRANDS"),
-        // Brand category (child of BRANDS)
-        makeCategory("rpm-cat", "RPM", "brands-cat"),
-        // Other category (not a brand)
-        makeCategory("putters-cat", "PUTTERS"),
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          description: "A putter",
-          imageIds: ["img-1"],
-          categoryIds: ["putters-cat", "rpm-cat"],
-          ecomUri: "https://example.com/ruru",
-          variations: [{ id: "var-1", priceAmount: 2200n }],
-        }),
-      ],
-      inventoryCounts: [makeInventoryCount("var-1", 5)],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items).toHaveLength(1);
-    expect(items[0].brand).toBe("RPM");
-  });
-
-  it("skips non-REGULAR product types", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/disc.jpg"),
-        makeItem({
-          id: "item-1",
-          name: "Regular Disc",
-          imageIds: ["img-1"],
-          ecomUri: "https://example.com/disc",
-          productType: "REGULAR",
-          variations: [{ id: "var-1", priceAmount: 2200n }],
-        }),
-        makeItem({
-          id: "item-2",
-          name: "Event Registration",
-          imageIds: ["img-1"],
-          ecomUri: "https://example.com/event",
-          productType: "EVENT",
-          variations: [{ id: "var-2", priceAmount: 1500n }],
-        }),
-        makeItem({
-          id: "item-3",
-          name: "Membership",
-          imageIds: ["img-1"],
-          ecomUri: "https://example.com/membership",
-          productType: "LEGACY_SQUARE_ONLINE_SERVICE",
-          variations: [{ id: "var-3", priceAmount: 5000n }],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 5),
-        makeInventoryCount("var-2", 10),
-        makeInventoryCount("var-3", 100),
-      ],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items).toHaveLength(1);
-    expect(items[0].name).toBe("Regular Disc");
-  });
-
-  it("skips items without price", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeItem({
-          id: "item-1",
-          name: "No Price Disc",
-          ecomUri: "https://example.com/disc",
-          variations: [{ id: "var-1" }], // no price
-        }),
-      ],
-      inventoryCounts: [makeInventoryCount("var-1", 5)],
-    };
-
-    const items = aggregateItems(data);
-
-    expect(items).toHaveLength(0);
-  });
-});
-
-describe("toGoogleProduct", () => {
-  const sampleItem: AggregatedItem = {
-    itemId: "item-1",
-    name: "Ruru",
-    description: "A putter disc",
-    productUrl: "https://mdgcshop.square.site/product/ruru/25",
-    imageUrl: "https://example.com/ruru.jpg",
-    category: "Putters",
-    minPrice: 2200,
-    currency: "AUD",
-    totalQuantity: 5,
-  };
-
-  it("converts aggregated item to Google format", () => {
-    const result = toGoogleProduct(sampleItem);
-
-    expect(result).toEqual({
-      id: "item-1",
-      title: "Ruru",
-      description: "A putter disc",
-      link: "https://mdgcshop.square.site/product/ruru/25",
-      image_link: "https://example.com/ruru.jpg",
-      availability: "in_stock",
-      price: "22.00 AUD",
-      condition: "new",
-      brand: undefined,
-      google_product_category: "Sporting Goods > Outdoor Recreation > Disc Golf",
-      product_type: "Putters",
-    });
-  });
-
-  it("sets availability to out_of_stock when quantity is 0", () => {
-    const outOfStock = { ...sampleItem, totalQuantity: 0 };
-    const result = toGoogleProduct(outOfStock);
-
-    expect(result.availability).toBe("out_of_stock");
-  });
-
-  it("uses title as description fallback", () => {
-    const noDescription = { ...sampleItem, description: "" };
-    const result = toGoogleProduct(noDescription);
-
-    expect(result.description).toBe("Ruru");
-  });
-
-  it("prefixes brand to title", () => {
-    const withBrand = { ...sampleItem, brand: "RPM" };
-    const result = toGoogleProduct(withBrand);
-
-    expect(result.title).toBe("RPM Ruru");
-  });
-
-  it("does not duplicate brand if name already starts with it", () => {
-    const alreadyPrefixed = { ...sampleItem, name: "RPM Ruru", brand: "RPM" };
-    const result = toGoogleProduct(alreadyPrefixed);
-
-    expect(result.title).toBe("RPM Ruru");
-  });
-
-  it("appends disc type to title", () => {
-    const withType = { ...sampleItem, discType: "Disc Golf Putter" };
-    const result = toGoogleProduct(withType);
-
-    expect(result.title).toBe("Ruru - Disc Golf Putter");
-  });
-
-  it("includes both brand and disc type in title", () => {
-    const withBoth = { ...sampleItem, brand: "RPM", discType: "Disc Golf Putter" };
-    const result = toGoogleProduct(withBoth);
-
-    expect(result.title).toBe("RPM Ruru - Disc Golf Putter");
-  });
-
-  it("omits disc type from title when not set", () => {
-    const noType = { ...sampleItem, brand: "RPM", discType: undefined };
-    const result = toGoogleProduct(noType);
-
-    expect(result.title).toBe("RPM Ruru");
-  });
-
-  it("uses item brand when available", () => {
-    const withBrand = { ...sampleItem, brand: "RPM" };
-    const result = toGoogleProduct(withBrand);
-
-    expect(result.brand).toBe("RPM");
-  });
-
-  it("leaves brand undefined when item has no brand", () => {
-    const noBrand = { ...sampleItem, brand: undefined };
-    const result = toGoogleProduct(noBrand);
-
-    expect(result.brand).toBeUndefined();
-  });
-
-  it("does not prefix brand to title when item has no brand", () => {
-    const noBrand = { ...sampleItem, brand: undefined };
-    const result = toGoogleProduct(noBrand);
-
-    expect(result.title).toBe("Ruru");
-  });
-});
-
 describe("generateTsvFeed", () => {
   const sampleData: SquareInventoryData = {
     catalogObjects: [
@@ -502,33 +197,37 @@ describe("generateTsvFeed", () => {
         description: "A putter",
         imageIds: ["img-1"],
         categoryId: "cat-1",
-        variations: [{ id: "var-1", name: "Atomic/Pink", priceAmount: 2200n }],
+        variations: [
+          { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+          { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
+        ],
       }),
     ],
-    inventoryCounts: [makeInventoryCount("var-1", 5)],
+    inventoryCounts: [
+      makeInventoryCount("var-1", 2),
+      makeInventoryCount("var-2", 3),
+    ],
   };
 
-  it("generates TSV with header row", () => {
+  it("generates TSV with header row including variation columns", () => {
+    const result = generateTsvFeed(sampleData);
+    const headers = result.split("\n")[0].split("\t");
+
+    expect(headers).toContain("item_group_id");
+    expect(headers).toContain("color");
+  });
+
+  it("generates one row per variation", () => {
     const result = generateTsvFeed(sampleData);
     const lines = result.split("\n");
 
-    expect(lines[0]).toBe(
-      "id\ttitle\tdescription\tlink\timage_link\tavailability\tprice\tcondition\tbrand\tgoogle_product_category\tproduct_type"
-    );
+    // 1 header + 2 variations
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain("var-1");
+    expect(lines[2]).toContain("var-2");
   });
 
-  it("generates aggregated data rows", () => {
-    const result = generateTsvFeed(sampleData);
-    const lines = result.split("\n");
-
-    expect(lines).toHaveLength(2); // header + 1 item
-    expect(lines[1]).toContain("item-1");
-    expect(lines[1]).toContain("Ruru");
-    expect(lines[1]).toContain("22.00 AUD");
-    expect(lines[1]).toContain("https://mdgcshop.square.site/product/ruru/item-1");
-  });
-
-  it("skips items without channels (no URL)", () => {
+  it("skips variations without channels (no URL)", () => {
     const data: SquareInventoryData = {
       ...sampleData,
       catalogObjects: [
@@ -537,23 +236,22 @@ describe("generateTsvFeed", () => {
           id: "item-2",
           name: "No Channels Disc",
           imageIds: ["img-1"],
-          channels: [], // no channels = no URL
-          variations: [{ id: "var-2", priceAmount: 2000n }],
+          channels: [],
+          variations: [{ id: "var-3", name: "ATOMIC/RED/175", priceAmount: 2000n }],
         }),
       ],
       inventoryCounts: [
         ...sampleData.inventoryCounts,
-        makeInventoryCount("var-2", 1),
+        makeInventoryCount("var-3", 1),
       ],
     };
 
     const result = generateTsvFeed(data);
-    const lines = result.split("\n");
 
-    expect(lines).toHaveLength(2); // header + 1 item (not 3)
+    expect(result).not.toContain("var-3");
   });
 
-  it("skips items without images", () => {
+  it("skips variations without images", () => {
     const data: SquareInventoryData = {
       ...sampleData,
       catalogObjects: [
@@ -561,25 +259,22 @@ describe("generateTsvFeed", () => {
         makeItem({
           id: "item-2",
           name: "No Image Disc",
-          // no imageIds
-          variations: [{ id: "var-2", priceAmount: 2000n }],
+          variations: [{ id: "var-3", name: "ATOMIC/RED/175", priceAmount: 2000n }],
         }),
       ],
       inventoryCounts: [
         ...sampleData.inventoryCounts,
-        makeInventoryCount("var-2", 1),
+        makeInventoryCount("var-3", 1),
       ],
     };
 
     const result = generateTsvFeed(data);
-    const lines = result.split("\n");
 
-    expect(lines).toHaveLength(2); // header + 1 item
+    expect(result).not.toContain("var-3");
   });
 
   it("escapes tabs and newlines in values", () => {
     const data: SquareInventoryData = {
-      ...sampleData,
       catalogObjects: [
         makeImage("img-1", "https://example.com/ruru.jpg"),
         makeItem({
@@ -587,9 +282,10 @@ describe("generateTsvFeed", () => {
           name: "Ruru",
           description: "Line 1\nLine 2\twith tab",
           imageIds: ["img-1"],
-          variations: [{ id: "var-1", priceAmount: 2200n }],
+          variations: [{ id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n }],
         }),
       ],
+      inventoryCounts: [makeInventoryCount("var-1", 5)],
     };
 
     const result = generateTsvFeed(data);
@@ -598,29 +294,32 @@ describe("generateTsvFeed", () => {
     expect(result).toContain("Line 1 Line 2 with tab");
   });
 
-  it("skips out-of-stock items", () => {
+  it("skips out-of-stock variations", () => {
     const data: SquareInventoryData = {
-      ...sampleData,
       catalogObjects: [
-        ...sampleData.catalogObjects,
+        makeImage("img-1", "https://example.com/ruru.jpg"),
         makeItem({
-          id: "item-2",
-          name: "Out of Stock Disc",
+          id: "item-1",
+          name: "Ruru",
           imageIds: ["img-1"],
-          variations: [{ id: "var-2", priceAmount: 2000n }],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
+          ],
         }),
       ],
       inventoryCounts: [
-        ...sampleData.inventoryCounts,
-        makeInventoryCount("var-2", 0),
+        makeInventoryCount("var-1", 0),
+        makeInventoryCount("var-2", 3),
       ],
     };
 
     const result = generateTsvFeed(data);
     const lines = result.split("\n");
 
-    expect(lines).toHaveLength(2); // header + 1 in-stock item
-    expect(result).not.toContain("Out of Stock Disc");
+    expect(lines).toHaveLength(2); // header + 1 in-stock variation
+    expect(result).not.toContain("var-1");
+    expect(result).toContain("var-2");
   });
 
   it("handles empty catalog", () => {
@@ -866,114 +565,4 @@ describe("variationToGoogleProduct", () => {
   });
 });
 
-describe("generateTsvFeed with variations", () => {
-  it("includes item_group_id and color columns", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/ruru.jpg"),
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          description: "A putter",
-          imageIds: ["img-1"],
-          variations: [
-            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
-            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
-          ],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 2),
-        makeInventoryCount("var-2", 3),
-      ],
-    };
 
-    const result = generateTsvFeed(data, { perVariation: true });
-    const lines = result.split("\n");
-    const headers = lines[0].split("\t");
-
-    expect(headers).toContain("item_group_id");
-    expect(headers).toContain("color");
-    // 1 header + 2 variations
-    expect(lines).toHaveLength(3);
-  });
-
-  it("uses variation ID as product ID", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/ruru.jpg"),
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          imageIds: ["img-1"],
-          variations: [
-            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
-          ],
-        }),
-      ],
-      inventoryCounts: [makeInventoryCount("var-1", 2)],
-    };
-
-    const result = generateTsvFeed(data, { perVariation: true });
-    const lines = result.split("\n");
-
-    expect(lines[1]).toContain("var-1");
-  });
-
-  it("skips out-of-stock variations", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/ruru.jpg"),
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          imageIds: ["img-1"],
-          variations: [
-            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
-            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
-          ],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 0),
-        makeInventoryCount("var-2", 3),
-      ],
-    };
-
-    const result = generateTsvFeed(data, { perVariation: true });
-    const lines = result.split("\n");
-
-    expect(lines).toHaveLength(2); // header + 1 in-stock variation
-    expect(result).not.toContain("var-1");
-    expect(result).toContain("var-2");
-  });
-
-  it("defaults to aggregated mode when perVariation is false", () => {
-    const data: SquareInventoryData = {
-      catalogObjects: [
-        makeImage("img-1", "https://example.com/ruru.jpg"),
-        makeItem({
-          id: "item-1",
-          name: "Ruru",
-          imageIds: ["img-1"],
-          variations: [
-            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
-            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
-          ],
-        }),
-      ],
-      inventoryCounts: [
-        makeInventoryCount("var-1", 2),
-        makeInventoryCount("var-2", 3),
-      ],
-    };
-
-    const result = generateTsvFeed(data);
-    const lines = result.split("\n");
-    const headers = lines[0].split("\t");
-
-    // Aggregated: 1 header + 1 item (not 2 variations)
-    expect(lines).toHaveLength(2);
-    expect(headers).not.toContain("item_group_id");
-  });
-});

--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -4,6 +4,7 @@ import {
   formatBrand,
   discTypeLabel,
   parseVariationColor,
+  normalizeColor,
   slugify,
   aggregateItems,
   expandVariations,
@@ -655,6 +656,37 @@ describe("parseVariationColor", () => {
 
   it("returns undefined for names with wrong number of parts", () => {
     expect(parseVariationColor("COSMIC/YELLOW")).toBeUndefined();
+  });
+});
+
+describe("normalizeColor", () => {
+  it("expands abbreviations", () => {
+    expect(normalizeColor("Lt blue")).toBe("Light blue");
+    expect(normalizeColor("Lt lilac swirl")).toBe("Light lilac");
+  });
+
+  it("strips 'trans' prefix", () => {
+    expect(normalizeColor("Trans pink")).toBe("Pink");
+    expect(normalizeColor("Trans lime")).toBe("Lime");
+    expect(normalizeColor("Trans orange")).toBe("Orange");
+  });
+
+  it("strips 'swirl' suffix", () => {
+    expect(normalizeColor("Pink swirl")).toBe("Pink");
+    expect(normalizeColor("Orange swirl")).toBe("Orange");
+    expect(normalizeColor("Blue-pink swirl")).toBe("Blue-pink");
+  });
+
+  it("passes through standard colors unchanged", () => {
+    expect(normalizeColor("Pink")).toBe("Pink");
+    expect(normalizeColor("Yellow")).toBe("Yellow");
+    expect(normalizeColor("Blue")).toBe("Blue");
+  });
+
+  it("returns undefined for non-color values", () => {
+    expect(normalizeColor("Idye3")).toBeUndefined();
+    expect(normalizeColor("Kotuku")).toBeUndefined();
+    expect(normalizeColor("Glow-white rim")).toBeUndefined();
   });
 });
 

--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -3,9 +3,13 @@ import {
   formatName,
   formatBrand,
   discTypeLabel,
+  parseVariationParts,
   parseVariationColor,
+  parseVariationWeight,
   normalizeColor,
   slugify,
+  parseFlightNumbers,
+  flightProductDetails,
   expandVariations,
   variationToGoogleProduct,
   generateTsvFeed,
@@ -335,6 +339,132 @@ describe("generateTsvFeed", () => {
   });
 });
 
+describe("parseVariationParts", () => {
+  it("splits standard PLASTIC/COLOR/WEIGHT format", () => {
+    expect(parseVariationParts("COSMIC/YELLOW/177")).toEqual({
+      plastic: "COSMIC",
+      color: "YELLOW",
+      weight: "177",
+    });
+  });
+
+  it("strips item name prefix", () => {
+    expect(parseVariationParts("RURU - ATOMIC/PINK/171")).toEqual({
+      plastic: "ATOMIC",
+      color: "PINK",
+      weight: "171",
+    });
+  });
+
+  it("returns undefined for non-standard names", () => {
+    expect(parseVariationParts("STANDARD")).toBeUndefined();
+    expect(parseVariationParts("COSMIC/YELLOW")).toBeUndefined();
+  });
+});
+
+describe("parseVariationWeight", () => {
+  it("extracts weight from standard format", () => {
+    expect(parseVariationWeight("COSMIC/YELLOW/177")).toBe("177 g");
+  });
+
+  it("extracts weight from prefixed variation name", () => {
+    expect(parseVariationWeight("RURU - ATOMIC/PINK/171")).toBe("171 g");
+  });
+
+  it("uses lower bound for weight ranges", () => {
+    expect(parseVariationWeight("MAVERICK - FUZION/ORANGE/166-9")).toBe("166 g");
+  });
+
+  it("strips trailing + from weight", () => {
+    expect(parseVariationWeight("COSMIC/BLUE/177+")).toBe("177 g");
+  });
+
+  it("returns undefined for non-standard names", () => {
+    expect(parseVariationWeight("STANDARD")).toBeUndefined();
+  });
+});
+
+describe("parseFlightNumbers", () => {
+  it("parses flight numbers and strips .0 suffix", () => {
+    const desc = "Great disc.\n\nSpeed: 7.0\nGlide: 4.0\nTurn: -1.5\nFade: 2.0";
+    expect(parseFlightNumbers(desc)).toEqual({
+      speed: "7",
+      glide: "4",
+      turn: "-1.5",
+      fade: "2",
+    });
+  });
+
+  it("parses integer flight numbers (case-insensitive)", () => {
+    const desc = "A good disc\n\nSPEED: 6\nGLIDE: 6\nTURN: -3\nFADE: 0";
+    expect(parseFlightNumbers(desc)).toEqual({
+      speed: "6",
+      glide: "6",
+      turn: "-3",
+      fade: "0",
+    });
+  });
+
+  it("returns undefined when flight numbers are missing", () => {
+    expect(parseFlightNumbers("Just a description")).toBeUndefined();
+  });
+
+  it("returns undefined when only some stats are present", () => {
+    expect(parseFlightNumbers("Speed: 7.0\nGlide: 4.0")).toBeUndefined();
+  });
+
+  it("ignores stat keywords in prose, matches the actual stats", () => {
+    const desc = "stable flight with a gentle late fade. The bead-less rim\n\nSPEED: 2\nGLIDE: 3\nTURN: 0\nFADE: 2";
+    const result = parseFlightNumbers(desc)!;
+    expect(result).toEqual({ speed: "2", glide: "3", turn: "0", fade: "2" });
+  });
+
+  it("returns undefined when one stat is missing", () => {
+    expect(parseFlightNumbers("SPEED: 5\nGLIDE: 4\nTURN: -1")).toBeUndefined();
+  });
+
+  it("returns undefined when a stat value is garbled", () => {
+    expect(parseFlightNumbers("SPEED: 5\nGLIDE: 5\nTURN: -!\nFADE: 1")).toBeUndefined();
+  });
+
+  it("parses flight numbers on a single line", () => {
+    const desc = "A great disc. SPEED: 9GLIDE: 5TURN: -1FADE: 2";
+    expect(parseFlightNumbers(desc)).toEqual({
+      speed: "9",
+      glide: "5",
+      turn: "-1",
+      fade: "2",
+    });
+  });
+
+  it("parses flight numbers without colons", () => {
+    const desc = "A disc\n\nSPEED: 3\nGLIDE 3\nTURN: -1\nFADE: 1";
+    expect(parseFlightNumbers(desc)).toEqual({
+      speed: "3",
+      glide: "3",
+      turn: "-1",
+      fade: "1",
+    });
+  });
+});
+
+describe("flightProductDetails", () => {
+  it("builds product_detail entries from flight numbers", () => {
+    const details = flightProductDetails({
+      speed: "7",
+      glide: "4",
+      turn: "-1.5",
+      fade: "2",
+    });
+    expect(details).toEqual([
+      "Flight ratings:Speed:7",
+      "Flight ratings:Glide:4",
+      "Flight ratings:Turn:-1.5",
+      "Flight ratings:Fade:2",
+    ]);
+  });
+});
+
 describe("parseVariationColor", () => {
   it("extracts color from PLASTIC/COLOR/WEIGHT format", () => {
     expect(parseVariationColor("COSMIC/YELLOW/177")).toBe("Yellow");
@@ -486,6 +616,70 @@ describe("expandVariations", () => {
     expect(items[0].variationId).toBe("var-2");
   });
 
+  it("extracts weight from variation name", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+          ],
+        }),
+      ],
+      inventoryCounts: [makeInventoryCount("var-1", 1)],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items[0].weight).toBe("171 g");
+  });
+
+  it("builds product highlights from flight numbers in description", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          description: "A putter\n\nSpeed: 2.0\nGlide: 5.0\nTurn: 0\nFade: 1.0",
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+          ],
+        }),
+      ],
+      inventoryCounts: [makeInventoryCount("var-1", 1)],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items[0].productDetails).toEqual([
+      "Flight ratings:Speed:2",
+      "Flight ratings:Glide:5",
+      "Flight ratings:Turn:0",
+      "Flight ratings:Fade:1",
+    ]);
+  });
+
+  it("omits product details when description lacks flight numbers", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeItem({
+          id: "item-1",
+          name: "Disc bag",
+          description: "A bag for discs",
+          variations: [
+            { id: "var-1", name: "STANDARD", priceAmount: 5000n },
+          ],
+        }),
+      ],
+      inventoryCounts: [makeInventoryCount("var-1", 1)],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items[0].productDetails).toBeUndefined();
+  });
+
   it("inherits brand and disc type from parent item", () => {
     const data: SquareInventoryData = {
       catalogObjects: [
@@ -562,6 +756,26 @@ describe("variationToGoogleProduct", () => {
     expect(variationToGoogleProduct(sampleVariation).availability).toBe(
       "in_stock"
     );
+  });
+
+  it("includes product_weight when weight is set", () => {
+    const withWeight = { ...sampleVariation, weight: "171 g" };
+    const result = variationToGoogleProduct(withWeight);
+    expect(result.product_weight).toBe("171 g");
+  });
+
+  it("includes product_detail from flight numbers", () => {
+    const withDetails = {
+      ...sampleVariation,
+      productDetails: [
+        "Flight ratings:Speed:7",
+        "Flight ratings:Glide:5",
+        "Flight ratings:Turn:-2",
+        "Flight ratings:Fade:1",
+      ],
+    };
+    const result = variationToGoogleProduct(withDetails);
+    expect(result.product_detail).toBe("Flight ratings:Speed:7,Flight ratings:Glide:5,Flight ratings:Turn:-2,Flight ratings:Fade:1");
   });
 });
 

--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -646,7 +646,7 @@ describe("parseVariationColor", () => {
   });
 
   it("handles multi-word colors", () => {
-    expect(parseVariationColor("COSMIC/LIGHT BLUE/177+")).toBe("Light blue");
+    expect(parseVariationColor("COSMIC/LIGHT BLUE/177+")).toBe("Blue");
   });
 
   it("returns undefined for non-standard names", () => {
@@ -660,9 +660,12 @@ describe("parseVariationColor", () => {
 });
 
 describe("normalizeColor", () => {
-  it("expands abbreviations", () => {
-    expect(normalizeColor("Lt blue")).toBe("Light blue");
-    expect(normalizeColor("Lt lilac swirl")).toBe("Light lilac");
+  it("strips shade modifiers and abbreviations", () => {
+    expect(normalizeColor("Lt blue")).toBe("Blue");
+    expect(normalizeColor("Lt lilac swirl")).toBe("Lilac");
+    expect(normalizeColor("Dark pink")).toBe("Pink");
+    expect(normalizeColor("Pale pink")).toBe("Pink");
+    expect(normalizeColor("Fluorescent yellow")).toBe("Yellow");
   });
 
   it("strips 'trans' prefix", () => {

--- a/src/lib/google-feed.test.ts
+++ b/src/lib/google-feed.test.ts
@@ -3,11 +3,15 @@ import {
   formatName,
   formatBrand,
   discTypeLabel,
+  parseVariationColor,
   slugify,
   aggregateItems,
+  expandVariations,
   toGoogleProduct,
+  variationToGoogleProduct,
   generateTsvFeed,
   type AggregatedItem,
+  type VariationItem,
   type SquareInventoryData,
 } from "./google-feed.js";
 import type { CatalogObject, InventoryCount } from "square";
@@ -628,5 +632,304 @@ describe("generateTsvFeed", () => {
     const lines = result.split("\n");
 
     expect(lines).toHaveLength(1); // just header
+  });
+});
+
+describe("parseVariationColor", () => {
+  it("extracts color from PLASTIC/COLOR/WEIGHT format", () => {
+    expect(parseVariationColor("COSMIC/YELLOW/177")).toBe("Yellow");
+  });
+
+  it("extracts color from prefixed variation name", () => {
+    expect(parseVariationColor("RURU - ATOMIC/PINK/171")).toBe("Pink");
+  });
+
+  it("handles multi-word colors", () => {
+    expect(parseVariationColor("COSMIC/LIGHT BLUE/177+")).toBe("Light blue");
+  });
+
+  it("returns undefined for non-standard names", () => {
+    expect(parseVariationColor("STANDARD")).toBeUndefined();
+    expect(parseVariationColor("Original")).toBeUndefined();
+  });
+
+  it("returns undefined for names with wrong number of parts", () => {
+    expect(parseVariationColor("COSMIC/YELLOW")).toBeUndefined();
+  });
+});
+
+describe("expandVariations", () => {
+  it("produces one row per variation", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeImage("img-1", "https://example.com/ruru.jpg"),
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          description: "A putter",
+          imageIds: ["img-1"],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
+          ],
+        }),
+      ],
+      inventoryCounts: [
+        makeInventoryCount("var-1", 2),
+        makeInventoryCount("var-2", 3),
+      ],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      variationId: "var-1",
+      itemId: "item-1",
+      name: "Ruru",
+      color: "Pink",
+      price: 2200,
+      quantity: 2,
+    });
+    expect(items[1]).toMatchObject({
+      variationId: "var-2",
+      color: "Blue",
+      price: 2500,
+      quantity: 3,
+    });
+  });
+
+  it("includes out-of-stock variations", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeItem({
+          id: "item-1",
+          name: "Disc",
+          variations: [
+            { id: "var-1", name: "ATOMIC/RED/175", priceAmount: 2200n },
+          ],
+        }),
+      ],
+      inventoryCounts: [makeInventoryCount("var-1", 0)],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].quantity).toBe(0);
+  });
+
+  it("skips variations without price", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeItem({
+          id: "item-1",
+          name: "Disc",
+          variations: [
+            { id: "var-1", name: "ATOMIC/RED/175" }, // no price
+            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2200n },
+          ],
+        }),
+      ],
+      inventoryCounts: [
+        makeInventoryCount("var-1", 1),
+        makeInventoryCount("var-2", 1),
+      ],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].variationId).toBe("var-2");
+  });
+
+  it("inherits brand and disc type from parent item", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeCategory("brand-parent", "BRANDS"),
+        makeCategory("brand-rpm", "RPM", "brand-parent"),
+        makeCategory("dt-parent", "DISC TYPES"),
+        makeCategory("dt-putter", "PUTT AND APPROACH", "dt-parent"),
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          categoryIds: ["brand-rpm", "dt-putter"],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+          ],
+        }),
+      ],
+      inventoryCounts: [makeInventoryCount("var-1", 1)],
+    };
+
+    const items = expandVariations(data);
+
+    expect(items[0].brand).toBe("RPM");
+    expect(items[0].discType).toBe("Disc Golf Putter");
+  });
+});
+
+describe("variationToGoogleProduct", () => {
+  const sampleVariation: VariationItem = {
+    variationId: "var-1",
+    itemId: "item-1",
+    name: "Ruru",
+    description: "A putter disc",
+    productUrl: "https://mdgcshop.square.site/product/ruru/item-1",
+    imageUrl: "https://example.com/ruru-pink.jpg",
+    category: "DISCS",
+    brand: "RPM",
+    discType: "Disc Golf Putter",
+    color: "Pink",
+    price: 2200,
+    currency: "AUD",
+    quantity: 3,
+  };
+
+  it("uses variation ID as product ID", () => {
+    const result = variationToGoogleProduct(sampleVariation);
+    expect(result.id).toBe("var-1");
+  });
+
+  it("sets item_group_id to the parent item ID", () => {
+    const result = variationToGoogleProduct(sampleVariation);
+    expect(result.item_group_id).toBe("item-1");
+  });
+
+  it("includes color", () => {
+    const result = variationToGoogleProduct(sampleVariation);
+    expect(result.color).toBe("Pink");
+  });
+
+  it("uses variation-specific price", () => {
+    const result = variationToGoogleProduct(sampleVariation);
+    expect(result.price).toBe("22.00 AUD");
+  });
+
+  it("builds title with brand and disc type", () => {
+    const result = variationToGoogleProduct(sampleVariation);
+    expect(result.title).toBe("RPM Ruru - Disc Golf Putter");
+  });
+
+  it("sets availability from variation quantity", () => {
+    const outOfStock = { ...sampleVariation, quantity: 0 };
+    expect(variationToGoogleProduct(outOfStock).availability).toBe(
+      "out_of_stock"
+    );
+    expect(variationToGoogleProduct(sampleVariation).availability).toBe(
+      "in_stock"
+    );
+  });
+});
+
+describe("generateTsvFeed with variations", () => {
+  it("includes item_group_id and color columns", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeImage("img-1", "https://example.com/ruru.jpg"),
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          description: "A putter",
+          imageIds: ["img-1"],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
+          ],
+        }),
+      ],
+      inventoryCounts: [
+        makeInventoryCount("var-1", 2),
+        makeInventoryCount("var-2", 3),
+      ],
+    };
+
+    const result = generateTsvFeed(data, { perVariation: true });
+    const lines = result.split("\n");
+    const headers = lines[0].split("\t");
+
+    expect(headers).toContain("item_group_id");
+    expect(headers).toContain("color");
+    // 1 header + 2 variations
+    expect(lines).toHaveLength(3);
+  });
+
+  it("uses variation ID as product ID", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeImage("img-1", "https://example.com/ruru.jpg"),
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          imageIds: ["img-1"],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+          ],
+        }),
+      ],
+      inventoryCounts: [makeInventoryCount("var-1", 2)],
+    };
+
+    const result = generateTsvFeed(data, { perVariation: true });
+    const lines = result.split("\n");
+
+    expect(lines[1]).toContain("var-1");
+  });
+
+  it("skips out-of-stock variations", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeImage("img-1", "https://example.com/ruru.jpg"),
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          imageIds: ["img-1"],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
+          ],
+        }),
+      ],
+      inventoryCounts: [
+        makeInventoryCount("var-1", 0),
+        makeInventoryCount("var-2", 3),
+      ],
+    };
+
+    const result = generateTsvFeed(data, { perVariation: true });
+    const lines = result.split("\n");
+
+    expect(lines).toHaveLength(2); // header + 1 in-stock variation
+    expect(result).not.toContain("var-1");
+    expect(result).toContain("var-2");
+  });
+
+  it("defaults to aggregated mode when perVariation is false", () => {
+    const data: SquareInventoryData = {
+      catalogObjects: [
+        makeImage("img-1", "https://example.com/ruru.jpg"),
+        makeItem({
+          id: "item-1",
+          name: "Ruru",
+          imageIds: ["img-1"],
+          variations: [
+            { id: "var-1", name: "ATOMIC/PINK/171", priceAmount: 2200n },
+            { id: "var-2", name: "COSMIC/BLUE/170", priceAmount: 2500n },
+          ],
+        }),
+      ],
+      inventoryCounts: [
+        makeInventoryCount("var-1", 2),
+        makeInventoryCount("var-2", 3),
+      ],
+    };
+
+    const result = generateTsvFeed(data);
+    const lines = result.split("\n");
+    const headers = lines[0].split("\t");
+
+    // Aggregated: 1 header + 1 item (not 2 variations)
+    expect(lines).toHaveLength(2);
+    expect(headers).not.toContain("item_group_id");
   });
 });

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -142,9 +142,18 @@ export function normalizeColor(raw: string): string | undefined {
   // Capitalise first letter (may have been lowered by prefix stripping)
   color = color.charAt(0).toUpperCase() + color.slice(1);
 
+  // Convert hyphenated color pairs to Google's slash format
+  // e.g. "Lime-purple" -> "Lime/Purple"
+  if (color.includes("-")) {
+    const parts = color.split("-");
+    if (parts.every((p) => KNOWN_COLORS.has(p.toLowerCase()))) {
+      color = parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("/");
+    }
+  }
+
   // Check the base color is recognisable
   // For "Light blue", "Dark green" etc, check the second word
-  const words = color.split(/[\s-]/);
+  const words = color.split(/[\s\-\/]/);
   const baseColor = (
     /^(light|dark|pale|fluorescent)$/i.test(words[0]) && words.length > 1
       ? words[1]

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -18,6 +18,8 @@ export interface GoogleProduct {
   condition: "new" | "refurbished" | "used";
   brand?: string;
   gtin?: string;
+  item_group_id?: string;
+  color?: string;
   google_product_category?: string;
   product_type?: string;
 }
@@ -45,6 +47,42 @@ export interface AggregatedItem {
   minPrice: number;
   currency: string;
   totalQuantity: number;
+}
+
+/**
+ * A single variation, expanded from an aggregated item.
+ */
+export interface VariationItem {
+  variationId: string;
+  itemId: string;
+  name: string;
+  description: string;
+  productUrl?: string;
+  imageUrl?: string;
+  category?: string;
+  brand?: string;
+  discType?: string;
+  color?: string;
+  price: number;
+  currency: string;
+  quantity: number;
+}
+
+/**
+ * Parse a Square variation name to extract color.
+ * Variation names typically follow "PLASTIC/COLOR/WEIGHT" or
+ * "ITEM_NAME - PLASTIC/COLOR/WEIGHT".
+ * e.g., "COSMIC/YELLOW/177" -> "Yellow"
+ * e.g., "RURU - ATOMIC/PINK/171" -> "Pink"
+ */
+export function parseVariationColor(name: string): string | undefined {
+  // Strip item name prefix (e.g. "RURU - ATOMIC/PINK/171" -> "ATOMIC/PINK/171")
+  const stripped = name.includes(" - ") ? name.split(" - ").pop()! : name;
+  const parts = stripped.split("/");
+  if (parts.length !== 3) return undefined;
+
+  const rawColor = parts[1].trim();
+  return rawColor ? formatName(rawColor) : undefined;
 }
 
 /**
@@ -278,6 +316,138 @@ export function aggregateItems(data: SquareInventoryData): AggregatedItem[] {
 }
 
 /**
+ * Expand catalog items into one row per variation.
+ */
+export function expandVariations(data: SquareInventoryData): VariationItem[] {
+  const { images, categories, brandCategoryIds, discTypeCategoryIds, inventory } =
+    buildLookups(data);
+  const results: VariationItem[] = [];
+
+  for (const obj of data.catalogObjects) {
+    if (obj.type !== "ITEM" || !obj.id || !obj.itemData) continue;
+    if (obj.isDeleted || obj.itemData.isArchived) continue;
+    if (obj.itemData.productType !== "REGULAR") continue;
+
+    const itemData = obj.itemData;
+    const variations = itemData.variations ?? [];
+    if (variations.length === 0) continue;
+
+    // Item-level image (fallback for variations without their own)
+    const itemImageIds = itemData.imageIds ?? [];
+    const itemImageUrl =
+      itemImageIds.length > 0 ? images.get(itemImageIds[0]) : undefined;
+
+    const category = itemData.reportingCategory?.id
+      ? categories.get(itemData.reportingCategory.id)
+      : undefined;
+
+    let brand: string | undefined;
+    const itemCategories = itemData.categories ?? [];
+    for (const cat of itemCategories) {
+      if (cat.id && brandCategoryIds.has(cat.id)) {
+        const rawBrand = categories.get(cat.id);
+        brand = rawBrand ? formatBrand(rawBrand) : undefined;
+        break;
+      }
+    }
+
+    let discType: string | undefined;
+    for (const cat of itemCategories) {
+      if (cat.id && discTypeCategoryIds.has(cat.id)) {
+        const rawType = categories.get(cat.id);
+        discType = rawType ? discTypeLabel(rawType) : undefined;
+        break;
+      }
+    }
+
+    const hasChannels = (itemData.channels?.length ?? 0) > 0;
+    const ecomVisibility = (itemData as Record<string, unknown>)
+      .ecom_visibility as string | undefined;
+    const isVisible = ecomVisibility !== "UNAVAILABLE";
+    const slug = slugify(itemData.name ?? "");
+    const productUrl =
+      hasChannels && isVisible && slug
+        ? `https://${SHOP_DOMAIN}/product/${slug}/${obj.id}`
+        : undefined;
+
+    for (const variation of variations) {
+      if (variation.type !== "ITEM_VARIATION" || !variation.id) continue;
+      const varData = variation.itemVariationData;
+      if (!varData) continue;
+
+      const price = varData.priceMoney?.amount
+        ? Number(varData.priceMoney.amount)
+        : 0;
+      if (price <= 0) continue;
+
+      const quantity = inventory.get(variation.id) ?? 0;
+
+      // Per-variation image, falling back to item-level image
+      const varImageIds = (varData as Record<string, unknown>)
+        .imageIds as string[] | undefined;
+      const varImageUrl =
+        varImageIds && varImageIds.length > 0
+          ? images.get(varImageIds[0])
+          : undefined;
+
+      const color = varData.name
+        ? parseVariationColor(varData.name)
+        : undefined;
+
+      results.push({
+        variationId: variation.id,
+        itemId: obj.id,
+        name: formatName(itemData.name ?? ""),
+        description: itemData.description ?? "",
+        productUrl,
+        imageUrl: varImageUrl ?? itemImageUrl,
+        category,
+        brand,
+        discType,
+        color,
+        price,
+        currency: varData.priceMoney?.currency ?? "AUD",
+        quantity,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Convert a variation item to Google's format.
+ */
+export function variationToGoogleProduct(item: VariationItem): GoogleProduct {
+  const priceValue = (item.price / 100).toFixed(2);
+  const price = `${priceValue} ${item.currency}`;
+
+  let title = item.name;
+  if (item.brand && !title.startsWith(item.brand)) {
+    title = `${item.brand} ${title}`;
+  }
+  if (item.discType) {
+    title = `${title} - ${item.discType}`;
+  }
+
+  return {
+    id: item.variationId,
+    title,
+    description: item.description || item.name,
+    link: item.productUrl || "",
+    image_link: item.imageUrl || "",
+    availability: item.quantity > 0 ? "in_stock" : "out_of_stock",
+    price,
+    condition: "new",
+    brand: item.brand,
+    item_group_id: item.itemId,
+    color: item.color,
+    google_product_category: getGoogleProductCategory(item.category),
+    product_type: item.category,
+  };
+}
+
+/**
  * Map Square category to Google product category.
  * See: https://support.google.com/merchants/answer/6324436
  */
@@ -338,6 +508,12 @@ const FEED_COLUMNS: (keyof GoogleProduct)[] = [
   "product_type",
 ];
 
+const VARIATION_FEED_COLUMNS: (keyof GoogleProduct)[] = [
+  ...FEED_COLUMNS,
+  "item_group_id",
+  "color",
+];
+
 /**
  * Escape a value for TSV format.
  */
@@ -346,34 +522,58 @@ function escapeTsvValue(value: string | undefined): string {
   return value.replace(/[\t\n\r]/g, " ");
 }
 
+export interface FeedOptions {
+  perVariation?: boolean;
+}
+
 /**
  * Generate TSV feed content from Square inventory data.
  */
-export function generateTsvFeed(data: SquareInventoryData): string {
-  const lines: string[] = [];
+export function generateTsvFeed(
+  data: SquareInventoryData,
+  options?: FeedOptions
+): string {
+  if (options?.perVariation) {
+    return generateVariationFeed(data);
+  }
+  return generateAggregatedFeed(data);
+}
 
-  // Header row
+function generateAggregatedFeed(data: SquareInventoryData): string {
+  const lines: string[] = [];
   lines.push(FEED_COLUMNS.join("\t"));
 
-  // Aggregate variants into items
   const items = aggregateItems(data);
 
-  // Data rows
   for (const item of items) {
-    // Skip items without a product URL (can't link to them)
     if (!item.productUrl) continue;
-
-    // Skip items without images (Google requires images)
     if (!item.imageUrl) continue;
-
-    // Skip items without prices
     if (!item.minPrice || item.minPrice === Infinity) continue;
-
-    // Skip out-of-stock items
     if (item.totalQuantity <= 0) continue;
 
     const googleProduct = toGoogleProduct(item);
     const values = FEED_COLUMNS.map((col) =>
+      escapeTsvValue(googleProduct[col]?.toString())
+    );
+    lines.push(values.join("\t"));
+  }
+
+  return lines.join("\n");
+}
+
+function generateVariationFeed(data: SquareInventoryData): string {
+  const lines: string[] = [];
+  lines.push(VARIATION_FEED_COLUMNS.join("\t"));
+
+  const variations = expandVariations(data);
+
+  for (const item of variations) {
+    if (!item.productUrl) continue;
+    if (!item.imageUrl) continue;
+    if (item.quantity <= 0) continue;
+
+    const googleProduct = variationToGoogleProduct(item);
+    const values = VARIATION_FEED_COLUMNS.map((col) =>
       escapeTsvValue(googleProduct[col]?.toString())
     );
     lines.push(values.join("\t"));

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -139,6 +139,9 @@ export function normalizeColor(raw: string): string | undefined {
   // Strip "trans" (translucent) prefix — not a color
   color = color.replace(/^Trans(parent|lucent)?\s+/i, "");
 
+  // Strip shade modifiers — keep the base color
+  color = color.replace(/^(Light|Dark|Pale|Fluorescent)\s+/i, "");
+
   // Capitalise first letter (may have been lowered by prefix stripping)
   color = color.charAt(0).toUpperCase() + color.slice(1);
 
@@ -152,13 +155,7 @@ export function normalizeColor(raw: string): string | undefined {
   }
 
   // Check the base color is recognisable
-  // For "Light blue", "Dark green" etc, check the second word
-  const words = color.split(/[\s\-\/]/);
-  const baseColor = (
-    /^(light|dark|pale|fluorescent)$/i.test(words[0]) && words.length > 1
-      ? words[1]
-      : words[0]
-  ).toLowerCase();
+  const baseColor = color.split(/[\s\-\/]/)[0].toLowerCase();
   if (!KNOWN_COLORS.has(baseColor)) return undefined;
 
   return color;

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -33,24 +33,7 @@ export interface SquareInventoryData {
 }
 
 /**
- * An aggregated item (multiple variants combined into one).
- */
-export interface AggregatedItem {
-  itemId: string;
-  name: string;
-  description: string;
-  productUrl?: string;
-  imageUrl?: string;
-  category?: string;
-  brand?: string;
-  discType?: string;
-  minPrice: number;
-  currency: string;
-  totalQuantity: number;
-}
-
-/**
- * A single variation, expanded from an aggregated item.
+ * A single variation, extracted from Square catalog data.
  */
 export interface VariationItem {
   variationId: string;
@@ -248,113 +231,7 @@ function buildLookups(data: SquareInventoryData) {
 }
 
 /**
- * Aggregate catalog items (combining variants into single items).
- */
-export function aggregateItems(data: SquareInventoryData): AggregatedItem[] {
-  const { images, categories, brandCategoryIds, discTypeCategoryIds, inventory } =
-    buildLookups(data);
-  const itemMap = new Map<string, AggregatedItem>();
-
-  for (const obj of data.catalogObjects) {
-    if (obj.type !== "ITEM" || !obj.id || !obj.itemData) continue;
-    if (obj.isDeleted || obj.itemData.isArchived) continue;
-    // Only include regular products (not events, memberships, etc.)
-    if (obj.itemData.productType !== "REGULAR") continue;
-
-    const itemData = obj.itemData;
-    const variations = itemData.variations ?? [];
-    if (variations.length === 0) continue;
-
-    // Get image URL (first image)
-    const imageIds = itemData.imageIds ?? [];
-    const imageUrl = imageIds.length > 0 ? images.get(imageIds[0]) : undefined;
-
-    // Get category name (from reportingCategory or first category)
-    const category = itemData.reportingCategory?.id
-      ? categories.get(itemData.reportingCategory.id)
-      : undefined;
-
-    // Get brand from item's categories (find one that's a child of BRANDS)
-    let brand: string | undefined;
-    const itemCategories = itemData.categories ?? [];
-    for (const cat of itemCategories) {
-      if (cat.id && brandCategoryIds.has(cat.id)) {
-        const rawBrand = categories.get(cat.id);
-        brand = rawBrand ? formatBrand(rawBrand) : undefined;
-        break;
-      }
-    }
-
-    // Get disc type from item's categories (find one that's a child of DISC TYPES)
-    let discType: string | undefined;
-    for (const cat of itemCategories) {
-      if (cat.id && discTypeCategoryIds.has(cat.id)) {
-        const rawType = categories.get(cat.id);
-        discType = rawType ? discTypeLabel(rawType) : undefined;
-        break;
-      }
-    }
-
-    // Construct product URL if item is visible on the online store
-    // URL format: https://{domain}/product/{slug}/{item-id}
-    // Requires: ecom_visibility not UNAVAILABLE and has channels
-    const hasChannels = (itemData.channels?.length ?? 0) > 0;
-    // ecom_visibility exists in the raw JSON but is missing from the SDK types
-    const ecomVisibility = (itemData as Record<string, unknown>)
-      .ecom_visibility as string | undefined;
-    const isVisible = ecomVisibility !== "UNAVAILABLE";
-    const slug = slugify(itemData.name ?? "");
-    const productUrl =
-      hasChannels && isVisible && slug
-        ? `https://${SHOP_DOMAIN}/product/${slug}/${obj.id}`
-        : undefined;
-
-    // Aggregate price and quantity across all variations
-    let minPrice = Infinity;
-    let currency = "AUD";
-    let totalQuantity = 0;
-
-    for (const variation of variations) {
-      if (variation.type !== "ITEM_VARIATION" || !variation.id) continue;
-
-      const varData = variation.itemVariationData;
-      if (!varData) continue;
-      const quantity = inventory.get(variation.id) ?? 0;
-      const price = varData.priceMoney?.amount
-        ? Number(varData.priceMoney.amount)
-        : 0;
-
-      totalQuantity += quantity;
-      // Only consider in-stock variations for minimum price
-      if (quantity > 0 && price > 0 && price < minPrice) {
-        minPrice = price;
-        currency = varData.priceMoney?.currency ?? "AUD";
-      }
-    }
-
-    // Skip items without valid prices
-    if (minPrice === Infinity) continue;
-
-    itemMap.set(obj.id, {
-      itemId: obj.id,
-      name: formatName(itemData.name ?? ""),
-      description: itemData.description ?? "",
-      productUrl,
-      imageUrl,
-      category,
-      brand,
-      discType,
-      minPrice,
-      currency,
-      totalQuantity,
-    });
-  }
-
-  return Array.from(itemMap.values());
-}
-
-/**
- * Expand catalog items into one row per variation.
+ * Extract catalog items into one row per variation.
  */
 export function expandVariations(data: SquareInventoryData): VariationItem[] {
   const { images, categories, brandCategoryIds, discTypeCategoryIds, inventory } =
@@ -497,39 +374,6 @@ function getGoogleProductCategory(category?: string): string {
 }
 
 /**
- * Convert an aggregated item to Google's format.
- */
-export function toGoogleProduct(item: AggregatedItem): GoogleProduct {
-  // Format price as "29.00 AUD"
-  const priceValue = (item.minPrice / 100).toFixed(2);
-  const price = `${priceValue} ${item.currency}`;
-
-  // Build title: prefix brand, suffix disc type
-  // e.g. "Pekapeka" -> "RPM Pekapeka Midrange Disc"
-  let title = item.name;
-  if (item.brand && !title.startsWith(item.brand)) {
-    title = `${item.brand} ${title}`;
-  }
-  if (item.discType) {
-    title = `${title} - ${item.discType}`;
-  }
-
-  return {
-    id: item.itemId,
-    title,
-    description: item.description || item.name,
-    link: item.productUrl || "",
-    image_link: item.imageUrl || "",
-    availability: item.totalQuantity > 0 ? "in_stock" : "out_of_stock",
-    price,
-    condition: "new",
-    brand: item.brand,
-    google_product_category: getGoogleProductCategory(item.category),
-    product_type: item.category,
-  };
-}
-
-/**
  * Google feed column headers (order matters).
  */
 const FEED_COLUMNS: (keyof GoogleProduct)[] = [
@@ -542,14 +386,10 @@ const FEED_COLUMNS: (keyof GoogleProduct)[] = [
   "price",
   "condition",
   "brand",
-  "google_product_category",
-  "product_type",
-];
-
-const VARIATION_FEED_COLUMNS: (keyof GoogleProduct)[] = [
-  ...FEED_COLUMNS,
   "item_group_id",
   "color",
+  "google_product_category",
+  "product_type",
 ];
 
 /**
@@ -560,48 +400,12 @@ function escapeTsvValue(value: string | undefined): string {
   return value.replace(/[\t\n\r]/g, " ");
 }
 
-export interface FeedOptions {
-  perVariation?: boolean;
-}
-
 /**
  * Generate TSV feed content from Square inventory data.
  */
-export function generateTsvFeed(
-  data: SquareInventoryData,
-  options?: FeedOptions
-): string {
-  if (options?.perVariation) {
-    return generateVariationFeed(data);
-  }
-  return generateAggregatedFeed(data);
-}
-
-function generateAggregatedFeed(data: SquareInventoryData): string {
+export function generateTsvFeed(data: SquareInventoryData): string {
   const lines: string[] = [];
   lines.push(FEED_COLUMNS.join("\t"));
-
-  const items = aggregateItems(data);
-
-  for (const item of items) {
-    if (!item.productUrl) continue;
-    if (!item.imageUrl) continue;
-    if (!item.minPrice || item.minPrice === Infinity) continue;
-    if (item.totalQuantity <= 0) continue;
-
-    const googleProduct = toGoogleProduct(item);
-    const values = FEED_COLUMNS.map((col) =>
-      escapeTsvValue(googleProduct[col]?.toString())
-    );
-    lines.push(values.join("\t"));
-  }
-
-  return lines.join("\n");
-}
-
-function generateVariationFeed(data: SquareInventoryData): string {
-  const lines: string[] = [];
-  lines.push(VARIATION_FEED_COLUMNS.join("\t"));
 
   const variations = expandVariations(data);
 
@@ -611,7 +415,7 @@ function generateVariationFeed(data: SquareInventoryData): string {
     if (item.quantity <= 0) continue;
 
     const googleProduct = variationToGoogleProduct(item);
-    const values = VARIATION_FEED_COLUMNS.map((col) =>
+    const values = FEED_COLUMNS.map((col) =>
       escapeTsvValue(googleProduct[col]?.toString())
     );
     lines.push(values.join("\t"));

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -20,6 +20,8 @@ export interface GoogleProduct {
   gtin?: string;
   item_group_id?: string;
   color?: string;
+  product_weight?: string;
+  product_detail?: string;
   google_product_category?: string;
   product_type?: string;
 }
@@ -46,9 +48,31 @@ export interface VariationItem {
   brand?: string;
   discType?: string;
   color?: string;
+  weight?: string;
+  productDetails?: string[];
   price: number;
   currency: string;
   quantity: number;
+}
+
+/**
+ * Split a Square variation name into its PLASTIC/COLOR/WEIGHT parts.
+ * Handles optional item name prefix: "RURU - ATOMIC/PINK/171" -> ["ATOMIC", "PINK", "171"]
+ * Returns undefined if the name doesn't follow this format.
+ */
+export function parseVariationParts(
+  name: string,
+): { plastic: string; color: string; weight: string } | undefined {
+  const stripped = name.includes(" - ") ? name.split(" - ").pop()! : name;
+  const parts = stripped.split("/");
+  if (parts.length !== 3) return undefined;
+
+  const plastic = parts[0].trim();
+  const color = parts[1].trim();
+  const weight = parts[2].trim();
+  if (!plastic || !color || !weight) return undefined;
+
+  return { plastic, color, weight };
 }
 
 /**
@@ -59,14 +83,31 @@ export interface VariationItem {
  * e.g., "RURU - ATOMIC/PINK/171" -> "Pink"
  */
 export function parseVariationColor(name: string): string | undefined {
-  // Strip item name prefix (e.g. "RURU - ATOMIC/PINK/171" -> "ATOMIC/PINK/171")
-  const stripped = name.includes(" - ") ? name.split(" - ").pop()! : name;
-  const parts = stripped.split("/");
-  if (parts.length !== 3) return undefined;
+  const parsed = parseVariationParts(name);
+  if (!parsed) return undefined;
+  return normalizeColor(formatName(parsed.color));
+}
 
-  const rawColor = parts[1].trim();
-  if (!rawColor) return undefined;
-  return normalizeColor(formatName(rawColor));
+/**
+ * Parse a Square variation name to extract the weight in grams.
+ * Returns the weight formatted for Google's product_weight attribute.
+ * Weights may be single values ("177") or ranges ("166-9").
+ * For ranges, we use the lower bound.
+ * e.g., "COSMIC/YELLOW/177" -> "177 g"
+ * e.g., "ATOMIC/PINK/166-9" -> "166 g"
+ * e.g., "COSMIC/BLUE/177+" -> "177 g"
+ */
+export function parseVariationWeight(name: string): string | undefined {
+  const parsed = parseVariationParts(name);
+  if (!parsed) return undefined;
+
+  // Strip trailing "+" (means "or heavier")
+  const raw = parsed.weight.replace(/\+$/, "");
+  // Take the first number (handles ranges like "166-9")
+  const match = raw.match(/^(\d+)/);
+  if (!match) return undefined;
+
+  return `${match[1]} g`;
 }
 
 /**
@@ -159,6 +200,52 @@ export function discTypeLabel(categoryName: string): string | undefined {
     default:
       return undefined;
   }
+}
+
+/**
+ * Flight rating numbers for a disc golf disc.
+ */
+export interface FlightNumbers {
+  speed: string;
+  glide: string;
+  turn: string;
+  fade: string;
+}
+
+/**
+ * Parse flight numbers (Speed/Glide/Turn/Fade) from a product description.
+ * These appear in most disc descriptions in formats like:
+ *   "Speed: 7.0\nGlide: 4.0\nTurn: -1.5\nFade: 2.0"
+ *   "SPEED: 6\nGLIDE: 6\nTURN: -3\nFADE: 0"
+ */
+export function parseFlightNumbers(
+  description: string,
+): FlightNumbers | undefined {
+  const m = description.match(
+    /speed\s*:?\s*(-?\d[\d.]*)\s*glide\s*:?\s*(-?\d[\d.]*)\s*turn\s*:?\s*(-?\d[\d.]*)\s*fade\s*:?\s*(-?\d[\d.]*)/i,
+  );
+  if (!m) return undefined;
+
+  const strip = (v: string) => v.replace(/\.0$/, "");
+  return {
+    speed: strip(m[1]),
+    glide: strip(m[2]),
+    turn: strip(m[3]),
+    fade: strip(m[4]),
+  };
+}
+
+/**
+ * Build product_detail entries from flight numbers.
+ * Uses Google's TSV product_detail format: "section_name:attribute_name:attribute_value".
+ */
+export function flightProductDetails(flight: FlightNumbers): string[] {
+  return [
+    `Flight ratings:Speed:${flight.speed}`,
+    `Flight ratings:Glide:${flight.glide}`,
+    `Flight ratings:Turn:${flight.turn}`,
+    `Flight ratings:Fade:${flight.fade}`,
+  ];
 }
 
 /**
@@ -308,18 +395,29 @@ export function expandVariations(data: SquareInventoryData): VariationItem[] {
       const color = varData.name
         ? parseVariationColor(varData.name)
         : undefined;
+      const weight = varData.name
+        ? parseVariationWeight(varData.name)
+        : undefined;
+
+      const description = itemData.description ?? "";
+      const flight = parseFlightNumbers(description);
+      const productDetails = flight
+        ? flightProductDetails(flight)
+        : undefined;
 
       results.push({
         variationId: variation.id,
         itemId: obj.id,
         name: formatName(itemData.name ?? ""),
-        description: itemData.description ?? "",
+        description,
         productUrl,
         imageUrl: varImageUrl ?? itemImageUrl,
         category,
         brand,
         discType,
+        productDetails,
         color,
+        weight,
         price,
         currency: varData.priceMoney?.currency ?? "AUD",
         quantity,
@@ -357,6 +455,8 @@ export function variationToGoogleProduct(item: VariationItem): GoogleProduct {
     brand: item.brand,
     item_group_id: item.itemId,
     color: item.color,
+    product_weight: item.weight,
+    product_detail: item.productDetails?.join(","),
     google_product_category: getGoogleProductCategory(item.category),
     product_type: item.category,
   };
@@ -388,6 +488,8 @@ const FEED_COLUMNS: (keyof GoogleProduct)[] = [
   "brand",
   "item_group_id",
   "color",
+  "product_weight",
+  "product_detail",
   "google_product_category",
   "product_type",
 ];

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -105,6 +105,7 @@ const KNOWN_COLORS = new Set([
   "indigo",
   "lilac",
   "lime",
+  "magenta",
   "orange",
   "peach",
   "pearl",

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -82,7 +82,77 @@ export function parseVariationColor(name: string): string | undefined {
   if (parts.length !== 3) return undefined;
 
   const rawColor = parts[1].trim();
-  return rawColor ? formatName(rawColor) : undefined;
+  if (!rawColor) return undefined;
+  return normalizeColor(formatName(rawColor));
+}
+
+/**
+ * Standard color names that Google will recognise.
+ */
+const KNOWN_COLORS = new Set([
+  "amber",
+  "aqua",
+  "black",
+  "blue",
+  "bronze",
+  "brown",
+  "charcoal",
+  "cream",
+  "gold",
+  "grape",
+  "green",
+  "grey",
+  "indigo",
+  "lilac",
+  "lime",
+  "orange",
+  "peach",
+  "pearl",
+  "pink",
+  "purple",
+  "red",
+  "rose",
+  "sand",
+  "sunset",
+  "teal",
+  "turquoise",
+  "white",
+  "yellow",
+]);
+
+/**
+ * Normalize a raw color string from Square variation names into
+ * a Google-friendly color. Returns undefined if the value isn't
+ * a recognisable color.
+ */
+export function normalizeColor(raw: string): string | undefined {
+  let color = raw;
+
+  // Expand abbreviations
+  color = color.replace(/^Lt /i, "Light ");
+  color = color.replace(/^Dk /i, "Dark ");
+  color = color.replace(/^Fluro /i, "Fluorescent ");
+
+  // Strip modifiers that aren't color-relevant
+  color = color.replace(/\s+(swirl|burst|orbit|halo|marble|rim)$/i, "");
+
+  // Strip "trans" (translucent) prefix — not a color
+  color = color.replace(/^Trans(parent|lucent)?\s+/i, "");
+
+  // Capitalise first letter (may have been lowered by prefix stripping)
+  color = color.charAt(0).toUpperCase() + color.slice(1);
+
+  // Check the base color is recognisable
+  // For "Light blue", "Dark green" etc, check the second word
+  const words = color.split(/[\s-]/);
+  const baseColor = (
+    /^(light|dark|pale|fluorescent)$/i.test(words[0]) && words.length > 1
+      ? words[1]
+      : words[0]
+  ).toLowerCase();
+  if (!KNOWN_COLORS.has(baseColor)) return undefined;
+
+  return color;
 }
 
 /**

--- a/src/lib/google-feed.ts
+++ b/src/lib/google-feed.ts
@@ -87,41 +87,6 @@ export function parseVariationColor(name: string): string | undefined {
 }
 
 /**
- * Standard color names that Google will recognise.
- */
-const KNOWN_COLORS = new Set([
-  "amber",
-  "aqua",
-  "black",
-  "blue",
-  "bronze",
-  "brown",
-  "charcoal",
-  "cream",
-  "gold",
-  "grape",
-  "green",
-  "grey",
-  "indigo",
-  "lilac",
-  "lime",
-  "magenta",
-  "orange",
-  "peach",
-  "pearl",
-  "pink",
-  "purple",
-  "red",
-  "rose",
-  "sand",
-  "sunset",
-  "teal",
-  "turquoise",
-  "white",
-  "yellow",
-]);
-
-/**
  * Normalize a raw color string from Square variation names into
  * a Google-friendly color. Returns undefined if the value isn't
  * a recognisable color.
@@ -129,35 +94,31 @@ const KNOWN_COLORS = new Set([
 export function normalizeColor(raw: string): string | undefined {
   let color = raw;
 
-  // Expand abbreviations
-  color = color.replace(/^Lt /i, "Light ");
-  color = color.replace(/^Dk /i, "Dark ");
-  color = color.replace(/^Fluro /i, "Fluorescent ");
-
   // Strip modifiers that aren't color-relevant
   color = color.replace(/\s+(swirl|burst|orbit|halo|marble|rim)$/i, "");
 
-  // Strip "trans" (translucent) prefix — not a color
+  // Strip "trans" (translucent) prefix
   color = color.replace(/^Trans(parent|lucent)?\s+/i, "");
 
-  // Strip shade modifiers — keep the base color
-  color = color.replace(/^(Light|Dark|Pale|Fluorescent)\s+/i, "");
+  // Expand then strip shade modifiers — keep the base color
+  color = color.replace(/^Lt /i, "Light ");
+  color = color.replace(/^Dk /i, "Dark ");
+  color = color.replace(/^(Light|Dark|Pale|Fluro|Fluorescent)\s+/i, "");
 
   // Capitalise first letter (may have been lowered by prefix stripping)
   color = color.charAt(0).toUpperCase() + color.slice(1);
 
   // Convert hyphenated color pairs to Google's slash format
   // e.g. "Lime-purple" -> "Lime/Purple"
-  if (color.includes("-")) {
-    const parts = color.split("-");
-    if (parts.every((p) => KNOWN_COLORS.has(p.toLowerCase()))) {
-      color = parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("/");
-    }
-  }
+  color = color
+    .split("-")
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join("/");
 
-  // Check the base color is recognisable
-  const baseColor = color.split(/[\s\-\/]/)[0].toLowerCase();
-  if (!KNOWN_COLORS.has(baseColor)) return undefined;
+  // Reject values that don't look like colors
+  if (/\d/.test(color)) return undefined;
+  if (color.split(/[\s\/]/).length > 3) return undefined;
+  if (color.length > 40) return undefined;
 
   return color;
 }

--- a/src/pages/feeds/google-products.tsv.ts
+++ b/src/pages/feeds/google-products.tsv.ts
@@ -6,7 +6,7 @@ import { generateTsvFeed, type SquareInventoryData } from "@lib/google-feed";
 const data = inventoryData as unknown as SquareInventoryData;
 
 export const GET: APIRoute = async () => {
-  const tsvContent = generateTsvFeed(data, { perVariation: true });
+  const tsvContent = generateTsvFeed(data);
 
   return new Response(tsvContent, {
     headers: {

--- a/src/pages/feeds/google-products.tsv.ts
+++ b/src/pages/feeds/google-products.tsv.ts
@@ -6,7 +6,7 @@ import { generateTsvFeed, type SquareInventoryData } from "@lib/google-feed";
 const data = inventoryData as unknown as SquareInventoryData;
 
 export const GET: APIRoute = async () => {
-  const tsvContent = generateTsvFeed(data);
+  const tsvContent = generateTsvFeed(data, { perVariation: true });
 
   return new Response(tsvContent, {
     headers: {


### PR DESCRIPTION
Expands the Google Shopping feed from one row per item to one row per variation.

## What changes

- **284 rows** instead of 134 (one per Square variation, not one per item)
- Each variation gets its own **price** and **availability**
- **Per-variation images** where available (68% of variations), falling back to item image
- **Color** parsed from variation names (e.g. `ATOMIC/PINK/171` → Pink)
- **`item_group_id`** groups variations of the same product

## Why

More accurate pricing and availability per listing. Currently the aggregated feed shows the minimum price across all variants, which may not be representative.

## Caveats

- All variations share the same product page URL (Square Online does not support deep-linking to a specific variation — [open feature request](https://community.squareup.com/t5/Feature-Requests/Direct-link-to-item-variation-in-online-store/idi-p/790386))
- Impact on search ranking is uncertain — see #24 for analysis

## How to test

The feed is generated at build time. Compare output:

```bash
# Aggregated (current)
pnpm build && wc -l dist/feeds/google-products.tsv  # 134 rows

# Per-variation (this branch)
# Already enabled in this PR
pnpm build && wc -l dist/feeds/google-products.tsv  # 284 rows
```

Relates to #22, #24.